### PR TITLE
feat(rss): integrate RSS-Stats for subscription tracking

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -66,7 +66,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     rel="alternate"
     type="application/rss+xml"
     title={siteTitle}
-    href={new URL("rss.xml", Astro.site)}
+    href={new URL("feed/", Astro.site)}
 />
 <meta name="generator" content={Astro.generator} />
 <meta name="theme-color" content="#fffaf4" media="(prefers-color-scheme: light)" />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -141,7 +141,7 @@ const isActive = (href: string) => href === pathname || href === `/${firstSegmen
         rel="alternate"
         type="application/rss+xml"
         title={t(locale, "site.title")}
-        href={new URL("rss.xml", Astro.site)}
+        href={new URL("feed/", Astro.site)}
     />
 </header>
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -20,7 +20,7 @@ export const SOCIAL_LINKS = {
     steam: "https://steamcommunity.com/id/niracler/",
     douban: "https://www.douban.com/people/niracler/",
     folo: "https://app.folo.is/share/users/niracler",
-    rss: "/rss.xml",
+    rss: "/feed/",
 };
 
 // Meting API base URL (用于音乐播放器自动获取歌曲信息)

--- a/src/pages/feed.js
+++ b/src/pages/feed.js
@@ -1,9 +1,0 @@
-export async function GET() {
-    return new Response(null, {
-        status: 301,
-        headers: {
-            Location: "/rss.xml",
-            "Cache-Control": "public, max-age=86400",
-        },
-    });
-}


### PR DESCRIPTION
## Summary

- Remove `/feed` → `/rss.xml` redirect (now handled by RSS-Stats Worker)
- Update all RSS subscribe links (`SOCIAL_LINKS.rss`, `<link rel=alternate>`) to point to `/feed/`
- RSS-Stats Worker deployed separately, intercepts `/feed/*` and `/stats/*` via Cloudflare Workers Routes

## Context

RSS-Stats ([SpatioStu/RSS-Stats](https://github.com/SpatioStu/RSS-Stats)) is a Cloudflare Worker that proxies RSS requests, recording visitor stats in D1. It identifies 50+ RSS readers and tracks real subscribers.

- Worker config: [niracler/RSS-Stats](https://github.com/niracler/RSS-Stats)
- Dashboard: `niracler.com/stats/`
- `/rss.xml` still works directly (served by Pages, not tracked)

## Test plan

- [x] `pnpm build` passes
- [x] `curl https://niracler.com/feed/` returns valid RSS XML with `X-RSS-Stats: Active` header
- [x] `curl https://niracler.com/stats/` returns dashboard
- [x] `curl https://niracler.com/rss.xml` still works (unchanged)
- [x] Subscribe via RSS reader and verify it appears in stats dashboard