### PR TITLE
feat(comments): render markdown tables

### DIFF
--- a/src/components/CommentSection.astro
+++ b/src/components/CommentSection.astro
@@ -428,6 +428,48 @@ const heading = locale === "en" ? "Comments" : "评论";
         margin: var(--space-3) 0;
     }
 
+    /* Markdown tables in comments */
+    .comment-body .comment-table-wrapper {
+        margin: var(--space-3) 0;
+        overflow-x: auto;
+        border: 1px solid var(--color-border-soft);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-surface);
+    }
+
+    .comment-body table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.95em;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .comment-body thead {
+        background: color-mix(in srgb, var(--color-accent-soft) 55%, transparent);
+    }
+
+    .comment-body th,
+    .comment-body td {
+        padding: var(--space-2) var(--space-3);
+        text-align: left;
+        border-bottom: 1px solid var(--color-border-soft);
+        white-space: normal;
+        word-break: break-word;
+    }
+
+    .comment-body thead th {
+        color: var(--color-text-primary);
+        font-weight: 600;
+    }
+
+    .comment-body tbody tr:last-child td {
+        border-bottom: none;
+    }
+
+    .comment-body tbody tr:nth-child(even) {
+        background: color-mix(in srgb, var(--color-bg-surface) 82%, var(--color-bg-muted) 18%);
+    }
+
     /* Reply + edit action buttons */
     .comment-actions {
         margin-top: var(--space-2);

--- a/src/scripts/comments.ts
+++ b/src/scripts/comments.ts
@@ -214,6 +214,10 @@ let currentSort: CommentSort = "latest";
 
 const md = MarkdownIt({ linkify: true, breaks: true }).disable("heading");
 
+// Wrap tables so they can scroll horizontally on narrow screens.
+md.renderer.rules.table_open = () => '<div class="comment-table-wrapper"><table>';
+md.renderer.rules.table_close = () => "</table></div>";
+
 const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     allowedTags: [
         "b",
@@ -230,9 +234,27 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
         "pre",
         "blockquote",
         "hr",
+        "table",
+        "thead",
+        "tbody",
+        "tr",
+        "th",
+        "td",
+        "div",
     ],
     allowedAttributes: {
         a: ["href", "target", "rel"],
+        th: ["style"],
+        td: ["style"],
+        div: ["class"],
+    },
+    allowedClasses: {
+        div: ["comment-table-wrapper"],
+    },
+    allowedStyles: {
+        "*": {
+            "text-align": [/^left$/, /^right$/, /^center$/],
+        },
     },
 };
 


### PR DESCRIPTION
## Summary

评论区现在会渲染 Markdown 表格 —— 之前 `sanitize-html` 把 `<table>` 等标签全部过滤掉了，所以烤肉肉看到的那一长串对比被压成了一整段文字。

- `src/scripts/comments.ts`: 把 `table / thead / tbody / tr / th / td` 加进 `allowedTags`；`th/td` 允许 `style`，但 `allowedStyles` 只放行 `text-align: left | right | center`，也就是 GFM 的列对齐；另外允许一个带固定 class `comment-table-wrapper` 的 `div`。
- 覆写 markdown-it 的 `table_open / table_close`，把表格包进 `.comment-table-wrapper`，这样宽表格在手机上可以横向滚动而不是撑爆评论卡片。
- `src/components/CommentSection.astro`: 新增 `.comment-body` 下的表格样式，使用项目已有的 token（`--color-border-soft`、`--color-bg-surface`、`--color-accent-soft` 等），风格和正文 `.prose table` 保持一致，表头柔和着色、偶数行斑马纹。

## Test plan

- [x] `pnpm dev`，在任一文章评论里发一条带表格的评论，确认表头 / 对齐 / 斑马纹都对
- [x] 在窄屏（手机或 DevTools mobile 视图）下确认宽表格出现横向滚动，不撑破卡片
- [x] 用已有的 `| 项 | 价格 |` 这类简单 GFM 表格和带 `:---:` 对齐的表格分别测试一遍
- [x] 确认非表格评论（纯文本、列表、代码块、链接）的渲染没有回归

https://claude.ai/code/session_01UZEWV5opVjjhPryXeJ4gHW