### PR TITLE
fix(markdown): render GFM tables and footnotes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@
 - Install: `pnpm install`. Dev server: `pnpm dev`.
 - Build: `pnpm build`; local preview: `pnpm preview`.
 - Quality: `pnpm lint` (Biome) + `pnpm format`; use `pnpm astro check` when adding TS/MDX.
+- Design render check: `node scripts/check-design-rendering.mjs` (or `pnpm check:design` when pnpm is healthy).
+
+## Local Development Notes
+
+- Prefer scripts for repeatable local checks instead of manual workaround notes. `scripts/check-design-rendering.mjs` starts Astro when needed, uses `/design` without a trailing slash, and verifies GFM tables/footnotes.
+- If pnpm 11 rewrites a large `pnpm-lock.yaml` during an unrelated task, treat it as dependency-tooling churn and keep it out of the change unless the task is explicitly about dependency maintenance.
 
 ## Coding Style & Naming Conventions
 
@@ -21,7 +27,7 @@
 
 ## Testing Guidelines
 
-- No automated suite yet; Playwright is available if you add browser specs. Name them `*.spec.ts` under `tests/` and keep headless-friendly.
+- Lightweight Node regression tests live under `tests/`; run targeted tests with `node --test tests/<name>.test.mjs`. Playwright is available if you add browser specs. Name them `*.spec.ts` under `tests/` and keep headless-friendly.
 - For UI or script changes, at minimum run `pnpm build` then `pnpm preview` and interact with scripts in `src/scripts/`.
 
 ## Development Workflow

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { existsSync } from "node:fs";
 import cloudflare from "@astrojs/cloudflare";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
@@ -12,9 +13,12 @@ import rehypeImgSize from "rehype-img-size";
 import rehypeMermaid from "rehype-mermaid";
 import rehypePicture from "rehype-picture";
 import rehypeSlug from "rehype-slug";
+import remarkGfm from "remark-gfm";
 import { remarkAlert } from "remark-github-blockquote-alert";
 import Icons from "unplugin-icons/vite";
 import { remarkModifiedTime } from "./remark-modified-time.mjs";
+
+const localChromePath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 
 // https://astro.build/config
 export default defineConfig({
@@ -39,7 +43,7 @@ export default defineConfig({
     }),
 
     markdown: {
-        remarkPlugins: [remarkAlert, remarkModifiedTime],
+        remarkPlugins: [remarkGfm, remarkAlert, remarkModifiedTime],
         shikiConfig: {
             // 双主题配置：通过 CSS 变量控制，无需 !important
             themes: {
@@ -69,6 +73,9 @@ export default defineConfig({
                 rehypeMermaid,
                 {
                     strategy: "inline-svg", // 服务端渲染为内联 SVG
+                    launchOptions: existsSync(localChromePath)
+                        ? { executablePath: localChromePath }
+                        : undefined,
                 },
             ],
             rehypePicture,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "dev": "astro dev",
         "dev:clean": "lsof -ti:4321 | xargs kill -9 2>/dev/null; rm -rf node_modules/.vite node_modules/.astro; astro dev",
         "build": "astro build",
+        "check:design": "node scripts/check-design-rendering.mjs",
         "preview": "astro preview",
         "astro": "astro",
         "format": "biome format --write .",
@@ -57,23 +58,5 @@
         "unist-util-visit": "^5.1.0",
         "unplugin-icons": "^23.0.1",
         "wrangler": "^4.84.1"
-    },
-    "pnpm": {
-        "overrides": {
-            "undici": ">=7.24.6",
-            "mdast-util-to-hast": ">=13.2.1",
-            "diff": ">=8.0.3",
-            "devalue": ">=5.6.3",
-            "fast-xml-parser": ">=5.7.0",
-            "dompurify": ">=3.4.0",
-            "ajv": ">=8.18.0",
-            "lodash-es": ">=4.18.1",
-            "h3": ">=1.15.5"
-        },
-        "onlyBuiltDependencies": [
-            "esbuild",
-            "sharp",
-            "workerd"
-        ]
     }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,18 @@
+packages:
+  - "."
+
+overrides:
+  ajv: ">=8.18.0"
+  devalue: ">=5.6.3"
+  diff: ">=8.0.3"
+  dompurify: ">=3.4.0"
+  fast-xml-parser: ">=5.7.0"
+  h3: ">=1.15.5"
+  lodash-es: ">=4.18.1"
+  mdast-util-to-hast: ">=13.2.1"
+  undici: ">=7.24.6"
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - workerd

--- a/scripts/check-design-rendering.mjs
+++ b/scripts/check-design-rendering.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { rm } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
+
+const repoRoot = new URL("../", import.meta.url);
+const astroBin = new URL("../node_modules/.bin/astro", import.meta.url);
+const designUrl = "http://127.0.0.1:4321/design";
+const startupTimeoutMs = 90_000;
+
+async function fetchDesignPage() {
+    try {
+        const response = await fetch(designUrl);
+        return {
+            html: await response.text(),
+            status: response.status,
+        };
+    } catch {
+        return undefined;
+    }
+}
+
+function analyzeDesignPage(html) {
+    return {
+        footnoteRefCount: (html.match(/data-footnote-ref|class="footnote-ref"/g) ?? []).length,
+        footnotesCount: (html.match(/class="footnotes"|data-footnotes/g) ?? []).length,
+        rawFootnote: /\[\^\d+\]/.test(html),
+        rawPipeTable: html.includes("| HIG 原则"),
+        tableCount: (html.match(/<table/g) ?? []).length,
+    };
+}
+
+function assertDesignRendering(page) {
+    const result = analyzeDesignPage(page.html);
+    const failures = [];
+
+    if (page.status !== 200) failures.push(`expected HTTP 200, got ${page.status}`);
+    if (result.tableCount < 1) failures.push("expected at least one rendered table");
+    if (result.footnotesCount < 1) failures.push("expected rendered footnotes");
+    if (result.footnoteRefCount < 1) failures.push("expected rendered footnote references");
+    if (result.rawPipeTable) failures.push("raw pipe table text is visible");
+    if (result.rawFootnote) failures.push("raw footnote markers are visible");
+
+    if (failures.length > 0) {
+        console.error(JSON.stringify({ failures, ...result }, null, 2));
+        process.exitCode = 1;
+        return;
+    }
+
+    console.log(JSON.stringify({ status: page.status, ...result }, null, 2));
+}
+
+async function startAstroDevServer() {
+    await rm(new URL("../.astro", import.meta.url), { force: true, recursive: true });
+    await rm(new URL("../node_modules/.vite", import.meta.url), { force: true, recursive: true });
+
+    const child = spawn(astroBin.pathname, ["dev", "--host", "127.0.0.1", "--port", "4321"], {
+        cwd: repoRoot.pathname,
+        env: { ...process.env, FORCE_COLOR: "0" },
+        stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout.on("data", (chunk) => process.stderr.write(chunk));
+    child.stderr.on("data", (chunk) => process.stderr.write(chunk));
+
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < startupTimeoutMs) {
+        if (child.exitCode !== null) {
+            throw new Error(`Astro dev server exited with code ${child.exitCode}`);
+        }
+
+        const page = await fetchDesignPage();
+        if (page) return { child, page };
+        await delay(1_000);
+    }
+
+    child.kill("SIGTERM");
+    throw new Error(`Timed out waiting for ${designUrl}`);
+}
+
+let devServer;
+let page = await fetchDesignPage();
+
+if (!page) {
+    const started = await startAstroDevServer();
+    devServer = started.child;
+    page = started.page;
+}
+
+assertDesignRendering(page);
+
+if (devServer) {
+    devServer.kill("SIGTERM");
+}

--- a/tests/markdown-config.test.mjs
+++ b/tests/markdown-config.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("Astro markdown pipeline enables GitHub Flavored Markdown", async () => {
+    const config = await readFile(new URL("../astro.config.mjs", import.meta.url), "utf8");
+
+    assert.match(config, /import\s+remarkGfm\s+from\s+["']remark-gfm["']/);
+    assert.match(config, /remarkPlugins:\s*\[[^\]]*\bremarkGfm\b/s);
+});


### PR DESCRIPTION
## 背景

`/design` 的 GFM 语法没有进入 Markdown 管线，导致表格和脚注按普通文本输出。阅读入口处直接暴露 `| HIG 原则 ... |` 和 `[^1]`，问题集中在文章渲染层，不是样式层。

| Before | After |
| --- | --- |
| ![Before: pipe table and raw footnote markers](https://gist.githubusercontent.com/niracler/9a5684b1db702ae50707e7f4668f8a91/raw/e403dd7ea536fd047f0a061d1f1dbff5859e5011/before-design-broken.svg) | ![After: rendered table and footnote references](https://gist.githubusercontent.com/niracler/9a5684b1db702ae50707e7f4668f8a91/raw/b4af3b15a08501c592e8f869e34916028b381b56/after-design-fixed.svg) |

## 主要变更

- 启用 `remark-gfm`，恢复 GFM 表格和脚注渲染。
- 增加设计页渲染检查脚本，自动验证 `/design` 的表格、脚注和原始 Markdown 标记。
- 迁移 pnpm 11 仍需读取的构建脚本白名单，并为 Mermaid 本地渲染使用系统 Chrome fallback，保证验证流程可重复运行。

## 验证

- 页面回归：`node scripts/check-design-rendering.mjs` passed，确认 `/design` 的表格和脚注已渲染。
- 构建与提交检查：`astro build`、pre-commit hook passed。

## 注意事项

- 未修改 `pnpm-lock.yaml`；当前 lockfile 的重复 key 警告是已有问题。
- Astro 的 `markdown.remarkPlugins` deprecation 提示是独立迁移项，不在本次范围内。
