### PR TITLE
fix(deps): repair pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2912,10 +2912,6 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}


### PR DESCRIPTION
## 背景

main 部署在 `pnpm install --frozen-lockfile` 阶段失败。原因是 `pnpm-lock.yaml` 中 `postcss@8.5.15` 出现重复 mapping，pnpm 在 CI 中按 broken lockfile 处理。

## 主要变更

- 删除重复的 `postcss@8.5.15` lockfile 条目。

## 验证

- 部署卡点复现命令：`pnpm install --frozen-lockfile --config.strictDepBuilds=false` passed。
- 构建与提交检查：`astro build`、pre-commit hook passed。

## 注意事项

- 只修复 lockfile YAML 可解析性，不更新依赖版本。
