### PR TITLE
fix(deps): repair pnpm lockfile snapshots

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6806,12 +6806,6 @@ snapshots:
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
-    dependencies:
       nanoid: 3.3.13
       picocolors: 1.1.1
       source-map-js: 1.2.1


### PR DESCRIPTION
## 背景

#66 修复了 `packages:` 下的重复 `postcss@8.5.15`，部署仍在 `pnpm install --frozen-lockfile` 失败。最新失败点是 `snapshots:` 下还有一组重复的 `postcss@8.5.15`。

## 主要变更

- 删除 `snapshots:` 中重复的旧 `postcss@8.5.15` 条目。
- 保留当前解析使用的 `nanoid 3.3.13` 快照。

## 验证

- `pnpm install --frozen-lockfile --config.strictDepBuilds=false`：passed
- lockfile 重复 key 扫描：无重复项
- `astro build`：passed

## 注意事项

- 只修复 lockfile YAML 可解析性，不更新依赖版本。
