### PR TITLE
fix(deps): regenerate pnpm lockfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - Install: `pnpm install`. Dev server: `pnpm dev`.
 - Build: `pnpm build`; local preview: `pnpm preview`.
 - Quality: `pnpm lint` (Biome) + `pnpm format`; use `pnpm astro check` when adding TS/MDX.
+- Lockfile: `node scripts/check-lockfile.mjs` validates frozen installs in a clean temporary workspace.
 - Design render check: `node scripts/check-design-rendering.mjs` (or `pnpm check:design` when pnpm is healthy).
 
 ## Local Development Notes

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,17 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ajv: '>=8.18.0'
+  devalue: '>=5.6.3'
+  diff: '>=8.0.3'
+  dompurify: '>=3.4.0'
+  fast-xml-parser: '>=5.7.0'
+  h3: '>=1.15.5'
+  lodash-es: '>=4.18.1'
+  mdast-util-to-hast: '>=13.2.1'
+  undici: '>=7.24.6'
+
 importers:
 
   .:
@@ -1632,7 +1643,7 @@ packages:
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
-      ajv: ^8.5.0
+      ajv: '>=8.18.0'
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -2765,11 +2776,6 @@ packages:
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
-
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.13:
     resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
@@ -6657,8 +6663,6 @@ snapshots:
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
-
-  nanoid@3.3.12: {}
 
   nanoid@3.3.13: {}
 

--- a/scripts/check-lockfile.mjs
+++ b/scripts/check-lockfile.mjs
@@ -1,0 +1,37 @@
+import { spawnSync } from "node:child_process";
+import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const projectRoot = new URL("../", import.meta.url);
+const testRoot = await mkdtemp(join(tmpdir(), "bokushi-lockfile-"));
+
+try {
+    for (const filename of [".npmrc", "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"]) {
+        await copyFile(new URL(filename, projectRoot), join(testRoot, filename));
+    }
+
+    const result = spawnSync(
+        "pnpm",
+        ["install", "--frozen-lockfile", "--ignore-scripts", "--config.strictDepBuilds=false"],
+        {
+            cwd: testRoot,
+            encoding: "utf8",
+            env: { ...process.env, CI: "true" },
+        },
+    );
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    if (result.status === 0) {
+        console.log("Lockfile check passed in a clean workspace.");
+    } else {
+        process.stderr.write(result.stdout ?? "");
+        process.stderr.write(result.stderr ?? "");
+        process.exitCode = result.status ?? 1;
+    }
+} finally {
+    await rm(testRoot, { force: true, recursive: true });
+}


### PR DESCRIPTION
## 背景

#67 合并后，部署仍在 frozen install 阶段失败。根因是 overrides 已迁移到 `pnpm-workspace.yaml`，但 lockfile 元数据未同步；已有 `node_modules` 的本地安装会掩盖该问题。

## 主要变更

- 使用 pnpm 11.0.6 重生成 lockfile，同步 overrides 并清理失效快照。
- 新增干净临时目录校验，避免缓存导致假通过。

## 验证

- `node scripts/check-lockfile.mjs`：passed
- `pnpm build`：passed
- `pnpm lint`：passed
- `node scripts/check-design-rendering.mjs`：passed

## 注意事项

- 未升级依赖版本，无配置或环境变量变更。
