### PR TITLE
fix(security): resolve CodeQL findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "format": "biome format --write .",
         "lint": "biome check .",
         "lint:staged": "lint-staged",
-        "test": "node --test tests/*.test.mjs",
+        "test": "node --experimental-strip-types --test tests/*.test.mjs",
         "prepare": "husky"
     },
     "dependencies": {

--- a/src/components/PostPreviewSetup.astro
+++ b/src/components/PostPreviewSetup.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import { DEFAULT_POST_SOCIAL_IMAGE } from "../consts";
 import { extractDescription } from "../utils/extractDescription";
+import { serializeJsonForHtml } from "../utils/serializeJsonForHtml";
 
 interface PostMeta {
     title: string;
@@ -50,7 +51,7 @@ if (meta) {
 
 postMetaMap = normalizeMetaMap(postMetaMap);
 
-const serializedMeta = JSON.stringify(postMetaMap).replace(/</g, "\\u003c");
+const serializedMeta = serializeJsonForHtml(postMetaMap);
 ---
 <script id="all-posts-meta" type="application/json" set:html={serializedMeta} is:inline></script>
 <script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -19,6 +19,7 @@ import { extractDescription } from "../utils/extractDescription";
 import type { Locale } from "../utils/i18n";
 import { localePath } from "../utils/i18n";
 import { estimateReadingTime } from "../utils/readingTime";
+import { serializeJsonForHtml } from "../utils/serializeJsonForHtml";
 
 type BlogEntry = CollectionEntry<"blog"> | CollectionEntry<"monthly"> | CollectionEntry<"til">;
 
@@ -74,34 +75,40 @@ const slug = Astro.url.pathname.replace(/^\/|\/$/g, "");
 
 // 只有当文章有足够的标题时才显示目录（至少 2 个 h2/h3）
 const showToc = headings.filter((heading) => heading.depth >= 2 && heading.depth <= 3).length >= 2;
+
+const structuredData = serializeJsonForHtml({
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: title,
+    description: description,
+    image: new URL(imageSrc, Astro.site).toString(),
+    datePublished: pubDate.toISOString(),
+    ...(updatedDate
+        ? { dateModified: updatedDate.toISOString() }
+        : lastModified
+          ? { dateModified: new Date(lastModified).toISOString() }
+          : {}),
+    author: {
+        "@type": "Person",
+        name: "Niracler",
+        url: "https://www.niracler.com",
+    },
+    publisher: {
+        "@type": "Person",
+        name: "Niracler",
+    },
+    mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": new URL(Astro.url.pathname, Astro.site).toString(),
+    },
+    ...(tags && tags.length > 0 ? { keywords: tags.join(", ") } : {}),
+});
 ---
 
 <html lang={htmlLang}>
 	<head>
 		<BaseHead title={title} description={description} image={imageSrc} type="article" hreflangAlternates={hreflangAlternates} />
-		<script is:inline type="application/ld+json" set:html={JSON.stringify({
-			"@context": "https://schema.org",
-			"@type": "BlogPosting",
-			"headline": title,
-			"description": description,
-			"image": new URL(imageSrc, Astro.site).toString(),
-			"datePublished": pubDate.toISOString(),
-			...(updatedDate ? { "dateModified": updatedDate.toISOString() } : lastModified ? { "dateModified": new Date(lastModified).toISOString() } : {}),
-			"author": {
-				"@type": "Person",
-				"name": "Niracler",
-				"url": "https://www.niracler.com"
-			},
-			"publisher": {
-				"@type": "Person",
-				"name": "Niracler"
-			},
-			"mainEntityOfPage": {
-				"@type": "WebPage",
-				"@id": new URL(Astro.url.pathname, Astro.site).toString()
-			},
-			...(tags && tags.length > 0 ? { "keywords": tags.join(", ") } : {})
-		})} />
+		<script is:inline type="application/ld+json" set:html={structuredData} />
 	</head>
 
 	<body>

--- a/src/pages/api/auth/github/callback.ts
+++ b/src/pages/api/auth/github/callback.ts
@@ -117,7 +117,7 @@ export const GET: APIRoute = async ({ request }) => {
             .bind(githubId, userId, ghUser.login, ghUser.avatar_url, now)
             .run();
         if (!oauthResult.success) {
-            console.error("Failed to insert oauth_account:", oauthResult);
+            console.error("Failed to insert GitHub oauth_account");
             return Response.redirect(`${url.origin}${redirectUrl}`, 302);
         }
 

--- a/src/pages/api/auth/telegram/callback.ts
+++ b/src/pages/api/auth/telegram/callback.ts
@@ -81,7 +81,7 @@ export const POST: APIRoute = async ({ request }) => {
             .bind(telegramId, userId, data.username || displayName, avatarUrl, now)
             .run();
         if (!oauthResult.success) {
-            console.error("Failed to insert oauth_account:", oauthResult);
+            console.error("Failed to insert Telegram oauth_account");
             return jsonResponse({ error: "Internal server error" }, 500);
         }
 

--- a/src/pages/api/meting.ts
+++ b/src/pages/api/meting.ts
@@ -72,12 +72,9 @@ export const GET: APIRoute = async ({ request }) => {
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error("Meting API error:", message, error);
-        return new Response(
-            JSON.stringify({ error: "Failed to fetch from Netease", detail: message }),
-            {
-                status: 502,
-                headers: { "Content-Type": "application/json" },
-            },
-        );
+        return new Response(JSON.stringify({ error: "Failed to fetch from Netease" }), {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+        });
     }
 };

--- a/src/pages/channel-rss.xml.js
+++ b/src/pages/channel-rss.xml.js
@@ -1,4 +1,5 @@
 import rss from "@astrojs/rss";
+import * as cheerio from "cheerio";
 import sanitizeHtml from "sanitize-html";
 import { SITE_TITLE } from "../consts";
 import { fetchTelegramChannel } from "../utils/telegram";
@@ -28,15 +29,14 @@ function detectMediaType(content) {
  */
 function htmlToText(html) {
     if (!html) return "";
-    return html
-        .replace(/<div[^>]*class="telegram-images"[^>]*>[\s\S]*?<\/div>/g, "") // Remove image containers
-        .replace(/<br\s*\/?>/gi, "\n") // Convert br to newlines
-        .replace(/<\/p>/gi, "\n") // Convert closing p to newlines
-        .replace(/<[^>]+>/g, "") // Remove all HTML tags
-        .replace(/&nbsp;/g, " ")
-        .replace(/&lt;/g, "<")
-        .replace(/&gt;/g, ">")
-        .replace(/&amp;/g, "&")
+    const $ = cheerio.load(html, null, false);
+    $(".telegram-images").remove();
+    $("script, style, textarea, option, noscript").remove();
+    $("br").replaceWith("\n");
+    $("p").append("\n");
+    return $.root()
+        .text()
+        .replace(/\u00a0/g, " ")
         .trim();
 }
 
@@ -117,12 +117,10 @@ function generateTitle(content, maxLength = 80) {
  * - Removes emojis
  * - Limits to 200 characters
  */
-function generateDescription(html, maxLength = 200) {
-    if (!html) return "";
+function generateDescription(plainText, maxLength = 200) {
+    if (!plainText) return "";
 
-    // Strip HTML tags
-    let text = html
-        .replace(/<[^>]*>/g, "") // Remove HTML tags
+    let text = plainText
         .replace(/[\u{1F300}-\u{1F9FF}]/gu, "") // Remove emojis
         .replace(/\s+/g, " ") // Normalize whitespace
         .trim();
@@ -165,7 +163,7 @@ export async function GET(context) {
             items: channelData.posts.map((post) => {
                 const fixedContent = fixHashtagLinks(post.content, CHANNEL_USERNAME);
                 const cleanTitle = generateTitle(fixedContent);
-                const description = generateDescription(post.text);
+                const description = generateDescription(htmlToText(fixedContent));
 
                 return {
                     title: cleanTitle,

--- a/src/scripts/comments.ts
+++ b/src/scripts/comments.ts
@@ -1,5 +1,10 @@
 import MarkdownIt from "markdown-it";
 import sanitizeHtml from "sanitize-html";
+import {
+    bindOrderedImageFallbacks,
+    getCommentAvatarSources,
+    proxiedImageUrl,
+} from "../utils/avatarFallback";
 
 // --- Client-side i18n ---
 
@@ -265,17 +270,6 @@ function renderMarkdown(raw: string): string {
 
 // --- Avatar helpers ---
 
-/** Route external image through /api/image-proxy for CDN caching. */
-function proxied(url: string): string {
-    if (!url) return "";
-    return `/api/image-proxy?url=${encodeURIComponent(url)}`;
-}
-
-function gravatarUrl(hash: string | null): string {
-    if (!hash) return "";
-    return proxied(`https://www.gravatar.com/avatar/${hash}?d=404&s=48`);
-}
-
 /** Mask email for display: "lowbee.icu@outlook.com" → "low***@outlook.com" */
 function maskEmail(email: string): string {
     const [local, domain] = email.split("@");
@@ -284,47 +278,13 @@ function maskEmail(email: string): string {
     return `${visible}***@${domain}`;
 }
 
-function dicebearUrl(name: string): string {
-    return proxied(
-        `https://api.dicebear.com/9.x/bottts-neutral/svg?seed=${encodeURIComponent(name)}`,
-    );
-}
+const pendingAvatarFallbacks: string[][] = [];
 
-function faviconUrl(website: string | null): string {
-    if (!website) return "";
-    try {
-        const { hostname } = new URL(website);
-        return proxied(`https://www.google.com/s2/favicons?domain=${hostname}&sz=48`);
-    } catch {
-        return "";
-    }
+function bindAvatarFallbacks(container: HTMLElement): void {
+    const avatars = container.querySelectorAll<HTMLImageElement>("img.comment-avatar");
+    bindOrderedImageFallbacks(avatars, pendingAvatarFallbacks);
+    pendingAvatarFallbacks.length = 0;
 }
-
-function handleAvatarError(img: HTMLImageElement): void {
-    const fallbackAttr = img.getAttribute("data-fallback") || "";
-    const fallbacks = fallbackAttr.split(",").filter(Boolean);
-    if (fallbacks.length === 0) {
-        img.removeAttribute("onerror");
-        return;
-    }
-    const next = fallbacks.shift();
-    if (!next) {
-        img.removeAttribute("onerror");
-        return;
-    }
-    img.setAttribute("data-fallback", fallbacks.join(","));
-    img.src = next;
-    if (fallbacks.length === 0) {
-        img.removeAttribute("onerror");
-    }
-}
-
-declare global {
-    interface Window {
-        handleAvatarError: typeof handleAvatarError;
-    }
-}
-window.handleAvatarError = handleAvatarError;
 
 // --- Auth helpers ---
 
@@ -499,33 +459,13 @@ function renderCommentCard(comment: CommentNode, isReply = false, parentOverride
 			</div>`;
     }
 
-    let avatarSrc: string;
-    let fallbacks: string[];
-
-    if (comment.avatar_url) {
-        // OAuth user
-        avatarSrc = proxied(comment.avatar_url);
-        fallbacks = [dicebearUrl(comment.author)];
-    } else if (comment.gravatar_hash) {
-        // Anonymous with email
-        avatarSrc = gravatarUrl(comment.gravatar_hash);
-        fallbacks = [faviconUrl(comment.website), dicebearUrl(comment.author)].filter(
-            Boolean,
-        ) as string[];
-    } else if (comment.website) {
-        // Anonymous with website only
-        avatarSrc = faviconUrl(comment.website);
-        fallbacks = [dicebearUrl(comment.author)];
-    } else {
-        // No identity info
-        avatarSrc = dicebearUrl(comment.author);
-        fallbacks = [];
-    }
-
-    const onerrorAttr =
-        fallbacks.length > 0
-            ? ` onerror="handleAvatarError(this)" data-fallback="${fallbacks.join(",")}"`
-            : "";
+    const { src: avatarSrc, fallbacks } = getCommentAvatarSources({
+        author: comment.author,
+        avatarUrl: comment.avatar_url,
+        gravatarHash: comment.gravatar_hash,
+        website: comment.website,
+    });
+    pendingAvatarFallbacks.push(fallbacks);
 
     const authorEl = createAuthorEl(comment);
     const pinBadge =
@@ -595,12 +535,12 @@ function renderCommentCard(comment: CommentNode, isReply = false, parentOverride
     return `
 		<div class="comment-card${replyClass}" data-comment-id="${comment.id}">
 			<div style="display:flex;gap:0.75rem">
-				<img
-					src="${avatarSrc}"
-					alt=""
-					class="comment-avatar ${avatarClass}"
-					loading="lazy"${onerrorAttr}
-				/>
+					<img
+						src="${avatarSrc}"
+						alt=""
+						class="comment-avatar ${avatarClass}"
+						loading="lazy"
+					/>
 				<div style="min-width:0;flex:1">
 					<div class="comment-header">
 						${authorEl}
@@ -681,8 +621,8 @@ function renderCommentForm(parentId?: string, replyAuthor?: string): string {
 
     if (currentUser) {
         const avatarSrc = currentUser.avatar_url
-            ? escapeHtml(proxied(currentUser.avatar_url))
-            : proxied("https://www.gravatar.com/avatar/?d=mp&s=48");
+            ? escapeHtml(proxiedImageUrl(currentUser.avatar_url))
+            : proxiedImageUrl("https://www.gravatar.com/avatar/?d=mp&s=48");
         const adminBadge =
             currentUser.role === "admin" ? ` <span class="comment-badge">Admin</span>` : "";
 
@@ -808,6 +748,7 @@ function renderSortToolbar(total: number): string {
 }
 
 function renderCommentList(data: CommentsResponse): string {
+    pendingAvatarFallbacks.length = 0;
     if (data.comments.length === 0) {
         return `
 			${renderSortToolbar(data.total)}
@@ -1354,6 +1295,7 @@ async function loadComments(container: HTMLElement, slug: string) {
     try {
         const data = await fetchComments(slug, currentSort);
         container.innerHTML = renderCommentList(data);
+        bindAvatarFallbacks(container);
         bindEvents(container, slug);
     } catch {
         container.innerHTML =

--- a/src/utils/avatarFallback.ts
+++ b/src/utils/avatarFallback.ts
@@ -1,0 +1,94 @@
+interface CommentAvatarIdentity {
+    author: string;
+    avatarUrl: string | null;
+    gravatarHash: string | null;
+    website: string | null;
+}
+
+interface CommentAvatarSources {
+    src: string;
+    fallbacks: string[];
+}
+
+/** Route an external image through the local proxy for CDN caching. */
+export function proxiedImageUrl(url: string): string {
+    if (!url) return "";
+    return `/api/image-proxy?url=${encodeURIComponent(url)}`;
+}
+
+function gravatarUrl(hash: string | null): string {
+    if (!hash) return "";
+    return proxiedImageUrl(`https://www.gravatar.com/avatar/${hash}?d=404&s=48`);
+}
+
+function dicebearUrl(name: string): string {
+    return proxiedImageUrl(
+        `https://api.dicebear.com/9.x/bottts-neutral/svg?seed=${encodeURIComponent(name)}`,
+    );
+}
+
+function faviconUrl(website: string | null): string {
+    if (!website) return "";
+    try {
+        const { hostname } = new URL(website);
+        return proxiedImageUrl(`https://www.google.com/s2/favicons?domain=${hostname}&sz=48`);
+    } catch {
+        return "";
+    }
+}
+
+export function getCommentAvatarSources(identity: CommentAvatarIdentity): CommentAvatarSources {
+    if (identity.avatarUrl) {
+        return {
+            src: proxiedImageUrl(identity.avatarUrl),
+            fallbacks: [dicebearUrl(identity.author)],
+        };
+    }
+
+    if (identity.gravatarHash) {
+        return {
+            src: gravatarUrl(identity.gravatarHash),
+            fallbacks: [faviconUrl(identity.website), dicebearUrl(identity.author)].filter(
+                Boolean,
+            ) as string[],
+        };
+    }
+
+    if (identity.website) {
+        return {
+            src: faviconUrl(identity.website),
+            fallbacks: [dicebearUrl(identity.author)],
+        };
+    }
+
+    return { src: dicebearUrl(identity.author), fallbacks: [] };
+}
+
+export function bindImageFallbacks(img: HTMLImageElement, fallbacks: readonly string[]): void {
+    if (fallbacks.length === 0) return;
+
+    const remainingFallbacks = [...fallbacks];
+    const handleError = () => {
+        const next = remainingFallbacks.shift();
+        if (!next) {
+            img.removeEventListener("error", handleError);
+            return;
+        }
+
+        img.src = next;
+        if (remainingFallbacks.length === 0) {
+            img.removeEventListener("error", handleError);
+        }
+    };
+
+    img.addEventListener("error", handleError);
+}
+
+export function bindOrderedImageFallbacks(
+    images: Iterable<HTMLImageElement>,
+    fallbackSets: readonly (readonly string[])[],
+): void {
+    Array.from(images).forEach((img, index) => {
+        bindImageFallbacks(img, fallbackSets[index] ?? []);
+    });
+}

--- a/src/utils/readingTime.ts
+++ b/src/utils/readingTime.ts
@@ -9,43 +9,52 @@
  * - The two durations are summed and rounded up to at least 1 minute.
  */
 
+import * as cheerio from "cheerio";
+import MarkdownIt from "markdown-it";
+
 /** CJK Unified Ideographs + Extension A/B + Compatibility Ideographs */
 const CJK_REGEX =
     /[\u4e00-\u9fff\u3400-\u4dbf\u{20000}-\u{2a6df}\u{2a700}-\u{2b73f}\u{2b740}-\u{2b81f}\uf900-\ufaff]/gu;
 
 const CJK_CHARS_PER_MINUTE = 300;
 const WORDS_PER_MINUTE = 200;
+const markdownParser = new MarkdownIt({ html: true });
+
+function stripFrontmatter(text: string): string {
+    const firstLineEnd = text.indexOf("\n");
+    if (firstLineEnd === -1) return text;
+
+    const firstLine = text.slice(0, firstLineEnd).replace(/\r$/, "");
+    if (firstLine !== "---") return text;
+
+    let lineStart = firstLineEnd + 1;
+    while (lineStart <= text.length) {
+        const nextLineEnd = text.indexOf("\n", lineStart);
+        const lineEnd = nextLineEnd === -1 ? text.length : nextLineEnd;
+        const line = text.slice(lineStart, lineEnd).replace(/\r$/, "");
+
+        if (line === "---") {
+            return nextLineEnd === -1 ? "" : text.slice(nextLineEnd + 1);
+        }
+        if (nextLineEnd === -1) break;
+        lineStart = nextLineEnd + 1;
+    }
+
+    return text;
+}
 
 export function stripMarkdown(text: string): string {
-    return (
-        text
-            // Remove frontmatter
-            .replace(/^---[\s\S]*?---\s*/m, "")
-            // Remove fenced code blocks
-            .replace(/```[\s\S]*?```/g, "")
-            // Remove inline code
-            .replace(/`[^`]*`/g, "")
-            // Remove images
-            .replace(/!\[([^\]]*)\]\([^)]+\)/g, "")
-            // Remove links (keep link text)
-            .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-            // Remove heading markers
-            .replace(/^#{1,6}\s+/gm, "")
-            // Remove bold/italic markers
-            .replace(/(\*{1,2}|_{1,2})([^*_]+)\1/g, "$2")
-            // Remove blockquote markers
-            .replace(/^>\s+/gm, "")
-            // Remove list markers
-            .replace(/^[\s]*[-*+]\s+/gm, "")
-            .replace(/^[\s]*\d+\.\s+/gm, "")
-            // Remove horizontal rules
-            .replace(/^(-{3,}|_{3,}|\*{3,})$/gm, "")
-            // Remove HTML tags
-            .replace(/<[^>]+>/g, "")
-            // Collapse whitespace
-            .replace(/\s+/g, " ")
-            .trim()
-    );
+    const rendered = markdownParser.render(stripFrontmatter(text));
+    const $ = cheerio.load(rendered, null, false);
+
+    $("script, style, textarea, option, noscript, pre, code, img").remove();
+    $("br").replaceWith("\n");
+    $(
+        "address, article, aside, blockquote, div, dl, fieldset, footer, form, h1, h2, h3, h4, h5, h6, header, hr, li, main, nav, ol, p, section, table, ul",
+    ).append("\n");
+    $("td, th").append(" ");
+
+    return $.root().text().replace(/\s+/g, " ").trim();
 }
 
 export function estimateReadingTime(markdown: string | undefined): number {

--- a/src/utils/serializeJsonForHtml.ts
+++ b/src/utils/serializeJsonForHtml.ts
@@ -1,0 +1,8 @@
+/** Serialize JSON for an inline HTML script data block without allowing `</script>` breakout. */
+export function serializeJsonForHtml(value: unknown): string {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
+        throw new TypeError("Value cannot be serialized as JSON");
+    }
+    return serialized.replace(/</g, "\\u003c");
+}

--- a/src/utils/telegram.ts
+++ b/src/utils/telegram.ts
@@ -1,7 +1,29 @@
 import * as cheerio from "cheerio";
+import sanitizeHtml from "sanitize-html";
 
 /** Maximum input length for numbered list conversion to prevent ReDoS. */
 const MAX_NUMBERED_LIST_INPUT = 50_000;
+
+const TELEGRAM_CONTENT_SANITIZE_OPTIONS = {
+    allowedTags: [...sanitizeHtml.defaults.allowedTags, "img"],
+    allowedAttributes: {
+        ...sanitizeHtml.defaults.allowedAttributes,
+        a: ["href", "target", "rel"],
+        div: ["class"],
+        img: ["src", "alt", "loading", "class"],
+        span: ["class"],
+    },
+    allowedClasses: {
+        div: ["telegram-images"],
+        img: ["telegram-post-image"],
+        span: ["emoji"],
+    },
+};
+
+const TELEGRAM_DESCRIPTION_SANITIZE_OPTIONS = {
+    allowedTags: ["ol", "li"],
+    allowedAttributes: {},
+};
 
 /** Convert plain-text numbered lists (1. 2. 3.) into HTML <ol>/<li> markup. */
 function convertNumberedLists(text: string): string {
@@ -101,13 +123,13 @@ function getProxiedImageUrl(imageUrl: string): string {
  */
 function decodeHtmlEntities(text: string): string {
     return text
-        .replace(/&amp;/g, "&")
         .replace(/&lt;/g, "<")
         .replace(/&gt;/g, ">")
         .replace(/&quot;/g, '"')
         .replace(/&#0*39;/g, "'")
         .replace(/&#0*124;/g, "|")
-        .replace(/&nbsp;/g, " ");
+        .replace(/&nbsp;/g, " ")
+        .replace(/&amp;/g, "&");
 }
 
 /**
@@ -232,7 +254,10 @@ function parseChannelHtml(html: string, channelUsername: string): ParsedBatch {
     const title = $(".tgme_channel_info_header_title").text().trim();
     const $description = $(".tgme_channel_info_description");
     $description.find("br").replaceWith("\n");
-    const description = convertNumberedLists($description.text().trim());
+    const description = sanitizeHtml(
+        convertNumberedLists($description.text().trim()),
+        TELEGRAM_DESCRIPTION_SANITIZE_OPTIONS,
+    );
 
     const avatarSrc = $(".tgme_page_photo_image img").attr("src") || "";
     const avatar = getProxiedImageUrl(avatarSrc);
@@ -303,6 +328,10 @@ function parseChannelHtml(html: string, channelUsername: string): ParsedBatch {
                 .join("");
             contentHtml = `<div class="telegram-images">${imagesHtml}</div>${contentHtml}`;
         }
+
+        // Telegram is a remote HTML source. Sanitize once after every local transformation so
+        // all consumers, including Astro set:html, receive the same inert content.
+        contentHtml = sanitizeHtml(contentHtml, TELEGRAM_CONTENT_SANITIZE_OPTIONS);
 
         // Extract link preview
         let linkPreview: LinkPreview | undefined;

--- a/tests/channel-rss.test.mjs
+++ b/tests/channel-rss.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import * as nodeModule from "node:module";
+import test from "node:test";
+
+import { load, resolve } from "./extensionless-typescript-loader.mjs";
+
+if (typeof nodeModule.registerHooks === "function") {
+    nodeModule.registerHooks({ load, resolve });
+} else {
+    nodeModule.register("./extensionless-typescript-loader.mjs", import.meta.url);
+}
+
+const { GET } = await import("../src/pages/channel-rss.xml.js");
+
+function telegramChannelHtml(messageContent) {
+    return `
+        <div class="tgme_channel_info_header_title">Test channel</div>
+        <div class="tgme_channel_info_description">Test description</div>
+        <div class="tgme_widget_message_wrap">
+            <div class="tgme_widget_message" data-post="tomoko_channel/123">
+                <a class="tgme_widget_message_date">
+                    <time datetime="2026-07-13T00:00:00+00:00"></time>
+                </a>
+                <div class="tgme_widget_message_text">${messageContent}</div>
+            </div>
+        </div>
+    `;
+}
+
+async function renderChannelRss(messageContent) {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(telegramChannelHtml(messageContent));
+
+    try {
+        const response = await GET({ site: new URL("https://example.com/") });
+        assert.equal(response.status, 200);
+        return response.text();
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+}
+
+test("channel RSS description preserves comparison text", async () => {
+    const xml = await renderChannelRss("2 &lt; 3 and 5 &gt; 4");
+
+    assert.match(xml, /<description>2 &lt; 3 and 5 &gt; 4<\/description>/);
+});
+
+test("channel RSS descriptions use normalized sanitized content", async () => {
+    const xml = await renderChannelRss(
+        "hello<br>world <script>hidden</script><style>secret</style>Visible",
+    );
+
+    assert.match(xml, /<description>hello world Visible<\/description>/);
+    assert.doesNotMatch(xml, /hidden|secret/);
+});
+
+test("channel RSS titles omit non-text elements and preserve visible text", async () => {
+    const xml = await renderChannelRss(
+        "<script>hidden</script><style>secret</style>Visible <strong>headline</strong>",
+    );
+
+    assert.match(xml, /<title>Visible headline<\/title>/);
+    assert.doesNotMatch(xml, /hidden|secret/);
+});

--- a/tests/cloudflare-workers-stub.mjs
+++ b/tests/cloudflare-workers-stub.mjs
@@ -1,0 +1,1 @@
+export const env = globalThis.__TEST_CLOUDFLARE_ENV__;

--- a/tests/comment-avatar-fallback.test.mjs
+++ b/tests/comment-avatar-fallback.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+    bindImageFallbacks,
+    bindOrderedImageFallbacks,
+    getCommentAvatarSources,
+} from "../src/utils/avatarFallback.ts";
+
+class FakeImage {
+    src = "";
+    errorListeners = new Set();
+
+    addEventListener(type, listener) {
+        assert.equal(type, "error");
+        this.errorListeners.add(listener);
+    }
+
+    removeEventListener(type, listener) {
+        assert.equal(type, "error");
+        this.errorListeners.delete(listener);
+    }
+
+    dispatchError() {
+        for (const listener of [...this.errorListeners]) listener();
+    }
+}
+
+test("comment avatar fallbacks stay in JavaScript closures", async () => {
+    const source = await readFile(new URL("../src/scripts/comments.ts", import.meta.url), "utf8");
+    const fallbackSource = await readFile(
+        new URL("../src/utils/avatarFallback.ts", import.meta.url),
+        "utf8",
+    );
+
+    assert.doesNotMatch(source, /onerror=["'][^"']*handleAvatarError/);
+    assert.doesNotMatch(source, /getAttribute\(["']data-fallback["']\)/);
+    assert.doesNotMatch(source, /window\.handleAvatarError/);
+    assert.match(fallbackSource, /addEventListener\(["']error["']/);
+    assert.match(source, /bindOrderedImageFallbacks/);
+});
+
+test("OAuth avatar failure falls back once to DiceBear and exhausts its listener", () => {
+    const sources = getCommentAvatarSources({
+        author: "OAuth User",
+        avatarUrl: "https://avatars.example/user.png",
+        gravatarHash: "unused",
+        website: "https://example.com",
+    });
+    const image = new FakeImage();
+    image.src = sources.src;
+
+    bindImageFallbacks(image, sources.fallbacks);
+    image.dispatchError();
+
+    assert.match(sources.src, /avatars\.example/);
+    assert.match(image.src, /api\.dicebear\.com/);
+    assert.equal(image.errorListeners.size, 0);
+});
+
+test("avatar batches preserve index mapping and can bind a fresh reload", () => {
+    const oauth = getCommentAvatarSources({
+        author: "OAuth User",
+        avatarUrl: "https://avatars.example/user.png",
+        gravatarHash: null,
+        website: null,
+    });
+    const anonymous = getCommentAvatarSources({
+        author: "Anonymous User",
+        avatarUrl: null,
+        gravatarHash: "abc123",
+        website: "https://blog.example.com/about",
+    });
+    const firstLoad = [new FakeImage(), new FakeImage()];
+
+    bindOrderedImageFallbacks(firstLoad, [oauth.fallbacks, anonymous.fallbacks]);
+    firstLoad[0].dispatchError();
+    firstLoad[1].dispatchError();
+
+    assert.match(firstLoad[0].src, /api\.dicebear\.com/);
+    assert.match(firstLoad[1].src, /google\.com%2Fs2%2Ffavicons/);
+
+    const reloadedImage = new FakeImage();
+    bindOrderedImageFallbacks([reloadedImage], [anonymous.fallbacks]);
+    reloadedImage.dispatchError();
+
+    assert.match(reloadedImage.src, /google\.com%2Fs2%2Ffavicons/);
+    assert.equal(reloadedImage.errorListeners.size, 1);
+});
+
+test("anonymous avatar failures advance Gravatar to favicon to DiceBear in order", () => {
+    const sources = getCommentAvatarSources({
+        author: "Anonymous User",
+        avatarUrl: null,
+        gravatarHash: "abc123",
+        website: "https://blog.example.com/about",
+    });
+    const image = new FakeImage();
+    image.src = sources.src;
+
+    bindImageFallbacks(image, sources.fallbacks);
+    image.dispatchError();
+    const favicon = image.src;
+    assert.equal(image.errorListeners.size, 1);
+
+    image.dispatchError();
+
+    assert.match(sources.src, /gravatar\.com/);
+    assert.match(favicon, /google\.com%2Fs2%2Ffavicons/);
+    assert.match(image.src, /api\.dicebear\.com/);
+    assert.equal(image.errorListeners.size, 0);
+});

--- a/tests/extensionless-typescript-loader.mjs
+++ b/tests/extensionless-typescript-loader.mjs
@@ -1,0 +1,41 @@
+export function resolve(specifier, context, nextResolve) {
+    if (specifier === "cloudflare:workers") {
+        return {
+            shortCircuit: true,
+            url: new URL("./cloudflare-workers-stub.mjs", import.meta.url).href,
+        };
+    }
+
+    const tryTypeScriptExtension = (error) => {
+        const isRelative = specifier.startsWith("./") || specifier.startsWith("../");
+        const hasExtension = /\.[^/]+$/.test(specifier);
+        if (error?.code !== "ERR_MODULE_NOT_FOUND" || !isRelative || hasExtension) {
+            throw error;
+        }
+        return nextResolve(`${specifier}.ts`, context);
+    };
+
+    try {
+        const resolved = nextResolve(specifier, context);
+        return typeof resolved?.catch === "function"
+            ? resolved.catch(tryTypeScriptExtension)
+            : resolved;
+    } catch (error) {
+        return tryTypeScriptExtension(error);
+    }
+}
+
+export function load(url, context, nextLoad) {
+    const loaded = nextLoad(url, context);
+    const replaceAstroEnv = (result) => {
+        if (!url.endsWith("/src/consts.ts")) return result;
+        return {
+            ...result,
+            source: result.source.toString().replaceAll("import.meta.env.", "({})."),
+        };
+    };
+
+    return typeof loaded?.then === "function"
+        ? loaded.then(replaceAstroEnv)
+        : replaceAstroEnv(loaded);
+}

--- a/tests/html-json.test.mjs
+++ b/tests/html-json.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import * as nodeModule from "node:module";
+import test from "node:test";
+
+import { load, resolve } from "./extensionless-typescript-loader.mjs";
+
+if (typeof nodeModule.registerHooks === "function") {
+    nodeModule.registerHooks({ load, resolve });
+} else {
+    nodeModule.register("./extensionless-typescript-loader.mjs", import.meta.url);
+}
+
+const { extractDescription } = await import("../src/utils/extractDescription.ts");
+const { serializeJsonForHtml } = await import("../src/utils/serializeJsonForHtml.ts");
+
+test("HTML-embedded JSON cannot be closed by article description text", () => {
+    const description = extractDescription(
+        "<xmp></script><script>globalThis.pwned=1</script></xmp>",
+        200,
+    );
+    const serialized = serializeJsonForHtml({ description });
+
+    assert.doesNotMatch(serialized, /</);
+    assert.equal(JSON.parse(serialized).description, description);
+});

--- a/tests/meting-api.test.mjs
+++ b/tests/meting-api.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import * as nodeModule from "node:module";
+import test from "node:test";
+
+import { load, resolve } from "./extensionless-typescript-loader.mjs";
+
+if (typeof nodeModule.registerHooks === "function") {
+    nodeModule.registerHooks({ load, resolve });
+} else {
+    nodeModule.register("./extensionless-typescript-loader.mjs", import.meta.url);
+}
+
+const { GET } = await import("../src/pages/api/meting.ts");
+
+test("Meting API keeps upstream errors out of public responses", async () => {
+    const sensitiveMessage = "upstream request exposed an internal endpoint";
+    const originalFetch = globalThis.fetch;
+    const originalConsoleError = console.error;
+    const loggedErrors = [];
+
+    globalThis.fetch = async () => {
+        throw new Error(sensitiveMessage);
+    };
+    console.error = (...args) => loggedErrors.push(args);
+
+    try {
+        const response = await GET({
+            request: new Request("https://example.com/api/meting?type=url&id=123"),
+        });
+        const body = await response.json();
+
+        assert.equal(response.status, 502);
+        assert.deepEqual(body, { error: "Failed to fetch from Netease" });
+        assert.doesNotMatch(JSON.stringify(body), new RegExp(sensitiveMessage));
+        assert.match(loggedErrors.flat().join(" "), new RegExp(sensitiveMessage));
+    } finally {
+        globalThis.fetch = originalFetch;
+        console.error = originalConsoleError;
+    }
+});

--- a/tests/oauth-logging.test.mjs
+++ b/tests/oauth-logging.test.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import * as nodeModule from "node:module";
+import test from "node:test";
+
+import { load, resolve } from "./extensionless-typescript-loader.mjs";
+
+if (typeof nodeModule.registerHooks === "function") {
+    nodeModule.registerHooks({ load, resolve });
+} else {
+    nodeModule.register("./extensionless-typescript-loader.mjs", import.meta.url);
+}
+
+const testEnv = {};
+globalThis.__TEST_CLOUDFLARE_ENV__ = testEnv;
+
+const { GET: githubCallback } = await import("../src/pages/api/auth/github/callback.ts");
+const { POST: telegramCallback } = await import("../src/pages/api/auth/telegram/callback.ts");
+
+function databaseWithFailedOAuthInsert(sensitiveValue) {
+    return {
+        prepare(statement) {
+            return {
+                bind() {
+                    return this;
+                },
+                async first() {
+                    return null;
+                },
+                async run() {
+                    if (statement.includes("INSERT OR IGNORE INTO oauth_accounts")) {
+                        return { success: false, sensitiveValue };
+                    }
+                    return { success: true };
+                },
+            };
+        },
+    };
+}
+
+async function signTelegramAuth(botToken, data) {
+    const dataCheckString = Object.entries(data)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => `${key}=${value}`)
+        .join("\n");
+    const encoder = new TextEncoder();
+    const secret = await crypto.subtle.digest("SHA-256", encoder.encode(botToken));
+    const key = await crypto.subtle.importKey(
+        "raw",
+        secret,
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+    );
+    const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(dataCheckString));
+    return Array.from(new Uint8Array(signature), (byte) => byte.toString(16).padStart(2, "0")).join(
+        "",
+    );
+}
+
+test("GitHub OAuth does not log the failed database result object", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalConsoleError = console.error;
+    const loggedErrors = [];
+    const sensitiveValue = "private database diagnostic";
+
+    Object.assign(testEnv, {
+        ADMIN_GITHUB_ID: "999",
+        COMMENTS_DB: databaseWithFailedOAuthInsert(sensitiveValue),
+        GITHUB_CLIENT_ID: "client-id",
+        GITHUB_CLIENT_SECRET: "client-secret",
+        SESSIONS: {
+            async delete() {},
+            async get() {
+                return "/";
+            },
+        },
+    });
+
+    globalThis.fetch = async (input) => {
+        const url = input instanceof Request ? input.url : String(input);
+        if (url.includes("github.com/login/oauth/access_token")) {
+            return Response.json({
+                access_token: "access-token",
+                token_type: "bearer",
+                scope: "",
+            });
+        }
+        if (url === "https://api.github.com/user") {
+            return Response.json({
+                id: 123,
+                login: "octocat",
+                avatar_url: "https://example.com/avatar.png",
+                name: "Octo Cat",
+            });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+    };
+    console.error = (...args) => loggedErrors.push(args);
+
+    try {
+        const response = await githubCallback({
+            request: new Request(
+                "https://example.com/api/auth/github/callback?code=code&state=state",
+            ),
+        });
+
+        assert.equal(response.status, 302);
+        assert.deepEqual(loggedErrors, [["Failed to insert GitHub oauth_account"]]);
+        assert.doesNotMatch(JSON.stringify(loggedErrors), new RegExp(sensitiveValue));
+    } finally {
+        globalThis.fetch = originalFetch;
+        console.error = originalConsoleError;
+    }
+});
+
+test("Telegram OAuth does not log the failed database result object", async () => {
+    const originalConsoleError = console.error;
+    const loggedErrors = [];
+    const sensitiveValue = "private Telegram database diagnostic";
+    const botToken = "123456:test-token";
+    const authData = {
+        id: 456,
+        first_name: "Test",
+        username: "test-user",
+        auth_date: Math.floor(Date.now() / 1000),
+    };
+    const hash = await signTelegramAuth(botToken, authData);
+
+    Object.assign(testEnv, {
+        COMMENTS_DB: databaseWithFailedOAuthInsert(sensitiveValue),
+        SESSIONS: {},
+        TELEGRAM_BOT_TOKEN: botToken,
+    });
+    console.error = (...args) => loggedErrors.push(args);
+
+    try {
+        const response = await telegramCallback({
+            request: new Request("https://example.com/api/auth/telegram/callback", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ ...authData, hash }),
+            }),
+        });
+
+        assert.equal(response.status, 500);
+        assert.deepEqual(loggedErrors, [["Failed to insert Telegram oauth_account"]]);
+        assert.doesNotMatch(JSON.stringify(loggedErrors), new RegExp(sensitiveValue));
+    } finally {
+        console.error = originalConsoleError;
+    }
+});

--- a/tests/reading-time.test.mjs
+++ b/tests/reading-time.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { performance } from "node:perf_hooks";
+import test from "node:test";
+
+import { stripMarkdown } from "../src/utils/readingTime.ts";
+
+test("stripMarkdown removes active HTML together with its contents", () => {
+    const markdown = [
+        "# Safe title",
+        "<strong>Visible text</strong>",
+        '<script>alert("internal marker")</script>',
+        "<style>.hidden { color: red; }</style>",
+    ].join("\n");
+
+    assert.equal(stripMarkdown(markdown), "Safe title Visible text");
+});
+
+test("stripMarkdown preserves ordinary Markdown prose", () => {
+    const markdown = "Read **carefully** with [the guide](https://example.com) and `code`.";
+
+    assert.equal(stripMarkdown(markdown), "Read carefully with the guide and .");
+});
+
+test("stripMarkdown returns decoded plain text instead of HTML entities", () => {
+    assert.equal(stripMarkdown("Research & development"), "Research & development");
+});
+
+test("stripMarkdown handles malformed Markdown links in linear time", () => {
+    const malformedLinks = "![".repeat(24_000);
+    const startedAt = performance.now();
+
+    stripMarkdown(malformedLinks);
+
+    assert.ok(
+        performance.now() - startedAt < 1_000,
+        "malformed links should not trigger polynomial regex backtracking",
+    );
+});

--- a/tests/telegram-sanitization.test.mjs
+++ b/tests/telegram-sanitization.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import * as cheerio from "cheerio";
+import { fetchTelegramChannel } from "../src/utils/telegram.ts";
+
+function telegramChannelHtml(messageContent, description = "Test description") {
+    return `
+        <div class="tgme_channel_info_header_title">Test channel</div>
+        <div class="tgme_channel_info_description">${description}</div>
+        <div class="tgme_widget_message_wrap">
+            <div class="tgme_widget_message" data-post="test_channel/123">
+                <a class="tgme_widget_message_date">
+                    <time datetime="2026-07-13T00:00:00+00:00"></time>
+                </a>
+                <div class="tgme_widget_message_text">${messageContent}</div>
+            </div>
+        </div>
+    `;
+}
+
+async function parseChannel(messageContent, description) {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+        new Response(telegramChannelHtml(messageContent, description), {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+        });
+
+    try {
+        return await fetchTelegramChannel("test_channel", { minPosts: 1 });
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+}
+
+async function parseSinglePost(messageContent) {
+    const channel = await parseChannel(messageContent);
+    assert.equal(channel.posts.length, 1);
+    return channel.posts[0];
+}
+
+test("Telegram channel descriptions cannot inject active HTML", async () => {
+    const channel = await parseChannel("Safe post", "1. &lt;img src=x onerror=alert(1)&gt;");
+    const description = cheerio.load(channel.description, null, false);
+
+    assert.equal(description("img, script").length, 0);
+    assert.equal(description("ol").length, 1);
+});
+
+test("Telegram table cells cannot turn nested entities into executable HTML", async () => {
+    const post = await parseSinglePost(`
+        | Name | Value |
+        | --- | --- |
+        | Unsafe | &amp;lt;img src=x onerror=alert(1)&amp;gt; |
+    `);
+    const content = cheerio.load(post.content, null, false);
+
+    assert.equal(content("img[onerror], script").length, 0);
+    assert.equal(content("table").length, 1);
+    assert.equal(content("tbody td").last().text(), "<img src=x onerror=alert(1)>");
+});
+
+test("Telegram content removes active HTML while keeping safe images", async () => {
+    const post = await parseSinglePost(`
+        <img src="https://example.com/image.png" alt="Example" onerror="alert(1)">
+        <script>alert(2)</script>
+    `);
+    const content = cheerio.load(post.content, null, false);
+
+    assert.equal(content("script, img[onerror]").length, 0);
+    assert.equal(content("img").attr("src"), "https://example.com/image.png");
+    assert.equal(content("img").attr("alt"), "Example");
+});
+
+test("Telegram content keeps supported links and pipe tables", async () => {
+    const post = await parseSinglePost(`
+        | Project | Link |
+        | --- | --- |
+        | Bokushi | <a href="https://example.com">Website</a> |
+    `);
+    const content = cheerio.load(post.content, null, false);
+
+    assert.equal(content("table").length, 1);
+    assert.equal(content("tbody td").first().text(), "Bokushi");
+    assert.equal(content("a").attr("href"), "https://example.com");
+    assert.equal(content("a").attr("target"), "_blank");
+    assert.equal(content("a").attr("rel"), "noopener noreferrer");
+});


### PR DESCRIPTION
## 背景

依赖安全治理变更合并后，Dependabot 告警已经清零，但 CodeQL 仍保留 8 个源码级告警，涉及远程 HTML、正则复杂度、错误信息与数据库结果日志、头像回退 DOM 属性。此 PR 逐项关闭对应数据流，并补充可复现的回归测试。

## 主要变更

- 对 Telegram 帖子正文和频道简介在所有本地转换完成后统一清洗，阻断嵌套实体与 set:html 注入。
- 将 RSS 与阅读时长的 HTML/Markdown 提取改为解析器方案，补充畸形长输入的线性性能回归。
- 对嵌入 HTML 的 JSON 统一转义小于号，阻断 JSON-LD 的 script 闭合逃逸。
- 移除 Meting 公共响应中的上游错误细节，并避免记录 GitHub/Telegram OAuth 的 D1 结果对象。
- 将评论头像回退改为闭包事件监听器，并覆盖 OAuth、Gravatar、favicon、DiceBear 的顺序与生命周期。
- 为 Node 22.13 测试显式启用 TypeScript stripping，新增公开处理器和渲染边界测试。

## 验证

- `pnpm check:ci`：通过；Astro 112 个文件 0 diagnostics，26 个测试全部通过，依赖审计无已知漏洞，生产构建成功并索引 196 个页面。
- `npx -y node@22.13.0 --experimental-strip-types --test tests/*.test.mjs`：26/26 通过。
- `pnpm check:design`：通过；状态码 200，GFM 表格与脚注渲染正常。
- `node scripts/check-lockfile.mjs`：通过；clean workspace 中 lockfile 无漂移。
- pre-commit：lint-staged、字体覆盖、Astro 类型检查、依赖策略与 high 级审计全部通过。
- 独立代码审查：无剩余 Critical 或 Important 问题。

## 注意事项

- 不包含依赖版本、lockfile、公开 API、内容 Schema 或环境变量变更。
- CodeQL 告警状态需要等待此 PR 的 GitHub 扫描；合并后再以 main 分支复扫结果确认关闭。
- Astro 7 与现有 Markdown 配置弃用提示不在本次范围内。